### PR TITLE
Install "data/lua"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ def package_files(directory):
 
 extra_files_ui = package_files('./data/ui')
 extra_files_media = package_files('./data/media')
+extra_files_lua = package_files('./data/lua')
 from pprint import pprint
 pprint(extra_files_ui)
 pprint(extra_files_media)
@@ -79,6 +80,7 @@ setup(
         (app_prefix + '/share/icons/hicolor/scalable/apps', ['data/media/uberwriter.svg']),
         (app_prefix + '/share/applications', ['de.wolfvollprecht.UberWriter.desktop']),
         (app_prefix + '/opt/uberwriter/data/ui', extra_files_ui),
-        (app_prefix + '/opt/uberwriter/data/media', extra_files_media)
+        (app_prefix + '/opt/uberwriter/data/media', extra_files_media),
+        (app_prefix + '/opt/uberwriter/data/lua', extra_files_lua)
     ]
 )


### PR DESCRIPTION
Via https://github.com/wolfv/uberwriter/pull/45#issuecomment-381399975

Fixing this error:
```
Traceback (most recent call last):
  File "/app/lib/python3.5/site-packages/uberwriter-1.0-py3.5.egg/uberwriter/UberwriterWindow.py", line 711, in toggle_preview
    '--lua-filter=' + helpers.get_script_path('relative_to_absolute.lua'),
TypeError: Can't convert 'NoneType' object to str implicitly
```